### PR TITLE
add single value Postgres array helper methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
   - openjdk11
 install:
+  - git fetch --unshallow
   - git fetch --tags
   - git describe --tags
 script: ./gradlew check --stacktrace --info

--- a/src/main/java/com/kryptnostic/rhizome/hazelcast/serializers/RhizomeUtils.java
+++ b/src/main/java/com/kryptnostic/rhizome/hazelcast/serializers/RhizomeUtils.java
@@ -11,10 +11,10 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
 
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
@@ -70,7 +70,7 @@ public class RhizomeUtils {
         public static <T> Optional<T> deserializeToOptional(
                 ObjectDataInput in,
                 IoPerformingFunction<ObjectDataInput, T> deserializer ) throws IOException {
-            Optional<T> object = Optional.absent();
+            Optional<T> object = Optional.empty();
             if ( in.readBoolean() ) {
                 object = Optional.of( deserializer.apply( in ) );
             }

--- a/src/main/java/com/kryptnostic/rhizome/pods/AsyncPod.java
+++ b/src/main/java/com/kryptnostic/rhizome/pods/AsyncPod.java
@@ -44,11 +44,11 @@ public class AsyncPod implements AsyncConfigurer, SchedulingConfigurer {
     @Bean(
             destroyMethod = "shutdown" )
     public ThreadPoolTaskExecutor getAsyncExecutor() {
+        int minPoolSize = 4;
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize( 4 );
-        int maxPool = Math.max( 1, Runtime.getRuntime().availableProcessors() );
-        executor.setMaxPoolSize( maxPool );
-        logger.info("Setting MaxPoolSize to " + maxPool );
+        executor.setCorePoolSize( minPoolSize );
+        executor.setMaxPoolSize( Math.max( minPoolSize, Runtime.getRuntime().availableProcessors() );
+        logger.info("Setting MaxPoolSize to " + executor.getMaxPoolSize());
         executor.setThreadNamePrefix( "rhizome-offshoot-" );
         executor.initialize();
         return executor;

--- a/src/main/java/com/kryptnostic/rhizome/pods/AsyncPod.java
+++ b/src/main/java/com/kryptnostic/rhizome/pods/AsyncPod.java
@@ -47,7 +47,7 @@ public class AsyncPod implements AsyncConfigurer, SchedulingConfigurer {
         int minPoolSize = 4;
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize( minPoolSize );
-        executor.setMaxPoolSize( Math.max( minPoolSize, Runtime.getRuntime().availableProcessors() );
+        executor.setMaxPoolSize( Math.max( minPoolSize, Runtime.getRuntime().availableProcessors()));
         logger.info("Setting MaxPoolSize to " + executor.getMaxPoolSize());
         executor.setThreadNamePrefix( "rhizome-offshoot-" );
         executor.initialize();

--- a/src/main/java/com/kryptnostic/rhizome/pods/AsyncPod.java
+++ b/src/main/java/com/kryptnostic/rhizome/pods/AsyncPod.java
@@ -46,7 +46,9 @@ public class AsyncPod implements AsyncConfigurer, SchedulingConfigurer {
     public ThreadPoolTaskExecutor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize( 4 );
-        executor.setMaxPoolSize( Math.max( 1, Runtime.getRuntime().availableProcessors() ) );
+        int maxPool = Math.max( 1, Runtime.getRuntime().availableProcessors() );
+        executor.setMaxPoolSize( maxPool );
+        logger.info("Setting MaxPoolSize to " + maxPool );
         executor.setThreadNamePrefix( "rhizome-offshoot-" );
         executor.initialize();
         return executor;

--- a/src/main/java/com/openlattice/postgres/PostgresArrays.java
+++ b/src/main/java/com/openlattice/postgres/PostgresArrays.java
@@ -54,32 +54,24 @@ public class PostgresArrays {
         return connection.createArrayOf( PostgresDatatype.UUID.sql(), ids.toArray( new UUID[ 0 ] ) );
     }
 
-    public static Array createUuidArray( Connection connection, UUID id ) throws SQLException {
-        return connection.createArrayOf( PostgresDatatype.UUID.sql(), new UUID[]{ id }  );
+    public static Array createUuidArray( Connection connection, UUID...id ) throws SQLException {
+        return connection.createArrayOf( PostgresDatatype.UUID.sql(), id );
     }
 
     public static Array createLongArray( Connection connection, Collection<Long> values ) throws SQLException {
         return connection.createArrayOf( PostgresDatatype.BIGINT.sql(), values.toArray( new Long[ 0 ] ) );
     }
 
-    public static Array createIntArray( Connection connection, Integer value ) throws SQLException {
-        return connection.createArrayOf( PostgresDatatype.INTEGER.sql(), new Integer[]{ value } );
+    public static Array createIntArray( Connection connection, Integer...value ) throws SQLException {
+        return connection.createArrayOf( PostgresDatatype.INTEGER.sql(), value );
     }
 
     public static Array createIntArray( Connection connection, Collection<Integer> values ) throws SQLException {
         return connection.createArrayOf( PostgresDatatype.INTEGER.sql(), values.toArray( new Integer[ 0 ] ) );
     }
 
-    public static Array createIntArray( Connection connection, Integer[] values ) throws SQLException {
-        return connection.createArrayOf( PostgresDatatype.INTEGER.sql(), values );
-    }
-
-    public static Array createLongArray( Connection connection, Long[] values ) throws SQLException {
-        return connection.createArrayOf( PostgresDatatype.BIGINT.sql(), values );
-    }
-
-    public static Array createLongArray( Connection connection, Long value ) throws SQLException {
-        return connection.createArrayOf( PostgresDatatype.BIGINT.sql(), new Long[]{ value } );
+    public static Array createLongArray( Connection connection, Long...value ) throws SQLException {
+        return connection.createArrayOf( PostgresDatatype.BIGINT.sql(), value );
     }
 
     public static Array createTextArray( Connection connection, Stream<String> ids ) throws SQLException {
@@ -90,8 +82,8 @@ public class PostgresArrays {
         return connection.createArrayOf( PostgresDatatype.TEXT.sql(), ids.toArray( new String[ 0 ] ) );
     }
 
-    public static Array createTextArray( Connection connection, String text ) throws SQLException {
-        return connection.createArrayOf( PostgresDatatype.TEXT.sql(), new String[]{ text } );
+    public static Array createTextArray( Connection connection, String...text ) throws SQLException {
+        return connection.createArrayOf( PostgresDatatype.TEXT.sql(), text );
     }
 
     public static Array createBooleanArray( Connection connection, Collection<Boolean> values ) throws SQLException {

--- a/src/main/java/com/openlattice/postgres/PostgresArrays.java
+++ b/src/main/java/com/openlattice/postgres/PostgresArrays.java
@@ -20,6 +20,7 @@
 
 package com.openlattice.postgres;
 
+import javax.annotation.Nullable;
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -27,7 +28,6 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
@@ -54,8 +54,16 @@ public class PostgresArrays {
         return connection.createArrayOf( PostgresDatatype.UUID.sql(), ids.toArray( new UUID[ 0 ] ) );
     }
 
+    public static Array createUuidArray( Connection connection, UUID id ) throws SQLException {
+        return connection.createArrayOf( PostgresDatatype.UUID.sql(), new UUID[]{ id }  );
+    }
+
     public static Array createLongArray( Connection connection, Collection<Long> values ) throws SQLException {
         return connection.createArrayOf( PostgresDatatype.BIGINT.sql(), values.toArray( new Long[ 0 ] ) );
+    }
+
+    public static Array createIntArray( Connection connection, Integer value ) throws SQLException {
+        return connection.createArrayOf( PostgresDatatype.INTEGER.sql(), new Integer[]{ value } );
     }
 
     public static Array createIntArray( Connection connection, Collection<Integer> values ) throws SQLException {
@@ -70,12 +78,20 @@ public class PostgresArrays {
         return connection.createArrayOf( PostgresDatatype.BIGINT.sql(), values );
     }
 
+    public static Array createLongArray( Connection connection, Long value ) throws SQLException {
+        return connection.createArrayOf( PostgresDatatype.BIGINT.sql(), new Long[]{ value } );
+    }
+
     public static Array createTextArray( Connection connection, Stream<String> ids ) throws SQLException {
         return connection.createArrayOf( PostgresDatatype.TEXT.sql(), ids.toArray( String[]::new ) );
     }
 
     public static Array createTextArray( Connection connection, Collection<String> ids ) throws SQLException {
         return connection.createArrayOf( PostgresDatatype.TEXT.sql(), ids.toArray( new String[ 0 ] ) );
+    }
+
+    public static Array createTextArray( Connection connection, String text ) throws SQLException {
+        return connection.createArrayOf( PostgresDatatype.TEXT.sql(), new String[]{ text } );
     }
 
     public static Array createBooleanArray( Connection connection, Collection<Boolean> values ) throws SQLException {


### PR DESCRIPTION
This PR:
- Adds single-value Postgres array creation helper methods
- uses Java Optional instead of Guava Optional
- Fixes a bug setting rhizome pool sizes on machines with less than 4 cores
- updates the travis build configuration to fetch more history to complete the build
- Defeats one curvyboi to bring victory