### PR TITLE
small cleanups

### DIFF
--- a/src/main/java/com/openlattice/postgres/CountdownConnectionCloser.java
+++ b/src/main/java/com/openlattice/postgres/CountdownConnectionCloser.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
+@Deprecated( since = "Use PostgresIterable instead" )
 public class CountdownConnectionCloser {
     private static final ExecutorService executor = Executors.newCachedThreadPool();
     private static final Logger          logger   = LoggerFactory.getLogger( CountdownConnectionCloser.class );

--- a/src/main/java/com/openlattice/postgres/KeyIterator.java
+++ b/src/main/java/com/openlattice/postgres/KeyIterator.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
+@Deprecated( since = "Use PostgresIterable instead" )
 public class KeyIterator<T> implements Iterator<T> {
     private static final Logger logger = LoggerFactory.getLogger( KeyIterator.class );
     private final ResultSet                 rs;

--- a/src/main/java/com/openlattice/postgres/PostgresTableDefinition.java
+++ b/src/main/java/com/openlattice/postgres/PostgresTableDefinition.java
@@ -305,7 +305,7 @@ public class PostgresTableDefinition implements TableDefinition {
                     .filter( c -> !this.columns.contains( c ) )
                     .map( PostgresColumnDefinition::getName )
                     .collect( Collectors.toList() );
-            String errMsg = "Table is missing requested columns: " + String.valueOf( missingColumns );
+            String errMsg = "Table is missing requested columns: " + missingColumns;
             logger.error( errMsg );
             throw new IllegalArgumentException( errMsg );
         }

--- a/src/main/java/com/openlattice/postgres/mapstores/AbstractBasePostgresMapstore.java
+++ b/src/main/java/com/openlattice/postgres/mapstores/AbstractBasePostgresMapstore.java
@@ -20,35 +20,15 @@
 
 package com.openlattice.postgres.mapstores;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import com.codahale.metrics.annotation.Timed;
-import com.dataloom.streams.StreamUtil;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.MapMaker;
-import com.google.common.collect.Sets;
-import com.hazelcast.config.MapConfig;
-import com.hazelcast.config.MapStoreConfig;
-import com.kryptnostic.rhizome.mapstores.TestableSelfRegisteringMapStore;
-import com.openlattice.postgres.CountdownConnectionCloser;
-import com.openlattice.postgres.KeyIterator;
-import com.openlattice.postgres.PostgresColumnDefinition;
 import com.openlattice.postgres.PostgresTableDefinition;
 import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;


### PR DESCRIPTION
This PR:
- uses PostgresIterable instead of KeyIterator+CountdownConnectionCloser
- deprecates KeyIterator and CountdownConnectionCloser since they're unused and PostgresIterable *appears* to be their replacement