### PR TITLE
Updating kotlin method generation in EntryProcessors

### DIFF
--- a/src/main/java/com/kryptnostic/rhizome/hazelcast/processors/AbstractRhizomeEntryProcessor.java
+++ b/src/main/java/com/kryptnostic/rhizome/hazelcast/processors/AbstractRhizomeEntryProcessor.java
@@ -6,6 +6,8 @@ import java.util.Map.Entry;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
 
+import javax.annotation.Nonnull;
+
 public abstract class AbstractRhizomeEntryProcessor<K, V, R>
         implements EntryProcessor<K, V>, EntryBackupProcessor<K, V> {
     private static final long serialVersionUID = 5060655249179605949L;
@@ -19,7 +21,7 @@ public abstract class AbstractRhizomeEntryProcessor<K, V, R>
     }
 
     @Override
-    public abstract R process( Map.Entry<K, V> entry );
+    public abstract R process( @Nonnull Map.Entry<K, V> entry );
 
     public AbstractRhizomeEntryProcessor( boolean applyOnBackup ) {
         this.applyOnBackup = applyOnBackup;

--- a/src/main/java/com/kryptnostic/rhizome/hazelcast/processors/AbstractUpdater.java
+++ b/src/main/java/com/kryptnostic/rhizome/hazelcast/processors/AbstractUpdater.java
@@ -47,7 +47,7 @@ public abstract class AbstractUpdater<K, V extends Collection<T>, T>
     @Override
     public Void process( Entry<K, V> entry ) {
         V currentObjects = entry.getValue();
-        if ( !( currentObjects instanceof SetProxy<?, ?> ) && currentObjects == null ) {
+        if ( currentObjects == null ) {
             currentObjects = newEmptyCollection();
         }
 


### PR DESCRIPTION
This PR:
- Mark Map.Entry as Nonnull
- Remove redundant check in AbstractUpdater