### PR TITLE
add AbstractReadOnlyRhizomeEP

### DIFF
--- a/src/main/kotlin/com/openlattice/rhizome/hazelcast/entryprocessors/AbstractReadOnlyRhizomeEntryProcessor.kt
+++ b/src/main/kotlin/com/openlattice/rhizome/hazelcast/entryprocessors/AbstractReadOnlyRhizomeEntryProcessor.kt
@@ -1,0 +1,6 @@
+package com.openlattice.rhizome.hazelcast.entryprocessors
+
+import com.hazelcast.core.ReadOnly
+import com.kryptnostic.rhizome.hazelcast.processors.AbstractRhizomeEntryProcessor
+
+abstract class AbstractReadOnlyRhizomeEntryProcessor<K, V, R>: AbstractRhizomeEntryProcessor<K, V, R>( false ), ReadOnly


### PR DESCRIPTION
This PR:
- Encodes the ReadOnly required constructor argument for entryProcessors into a single type