### PR TITLE
Add s3 listing iterables.

### DIFF
--- a/src/main/kotlin/com/geekbeast/rhizome/aws/S3FolderListingIterable.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/aws/S3FolderListingIterable.kt
@@ -1,9 +1,6 @@
 package com.geekbeast.rhizome.aws
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.ListObjectsV2Request
-import com.amazonaws.services.s3.model.ListObjectsV2Result
-import java.util.concurrent.locks.ReentrantLock
 
 /**
  *

--- a/src/main/kotlin/com/geekbeast/rhizome/aws/S3FolderListingIterable.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/aws/S3FolderListingIterable.kt
@@ -1,0 +1,87 @@
+package com.geekbeast.rhizome.aws
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.ListObjectsV2Request
+import com.amazonaws.services.s3.model.ListObjectsV2Result
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ *
+ * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
+ */
+class S3FolderListingIterable<T>(
+        private val s3: AmazonS3,
+        private val bucket: String,
+        private val folderPrefix: String,
+        private val maxKeys: Int = 1000,
+        private val delimiter: String = "/",
+        private val mapper: (String) -> T
+) : Iterable<T> {
+    override fun iterator(): Iterator<T> {
+        return S3FolderIterator(
+                s3, bucket, folderPrefix, maxKeys, delimiter, mapper
+        )
+    }
+
+}
+
+/**
+ * This class will list
+ */
+class S3FolderIterator<T> @JvmOverloads constructor(
+        private val s3: AmazonS3,
+        private val bucket: String,
+        private val folderPrefix: String,
+        private val maxKeys: Int = 1000,
+        private val delimiter: String = "/",
+        private val mapper: (String) -> T
+) : Iterator<T> {
+    private val lock = ReentrantLock()
+    private var continuationToken: String? = null
+    private var result = getNextListing()
+    private var index = 0
+
+    init {
+        continuationToken = result.nextContinuationToken
+    }
+
+    override fun next(): T {
+        val nextElem = try {
+            lock.lock()
+            require(hasNext()) { "No element available." }
+            if (index == result.commonPrefixes.size) {
+                result = getNextListing()
+                continuationToken =  result.nextContinuationToken
+                index = 0
+            }
+            result.commonPrefixes[index++]
+        } finally {
+            lock.unlock()
+        }
+
+        return mapper(nextElem.removePrefix(folderPrefix).removeSuffix(delimiter))
+    }
+
+    override fun hasNext(): Boolean {
+        return try {
+            lock.lock()
+            (index < result.commonPrefixes.size) || (continuationToken != null)
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    private fun getNextListing(): ListObjectsV2Result {
+        val request = ListObjectsV2Request()
+                .withBucketName(bucket)
+                .withPrefix(folderPrefix)
+                .withDelimiter(delimiter)
+                .withMaxKeys(maxKeys)
+
+        if (continuationToken != null) {
+            request.continuationToken = continuationToken
+        }
+
+        return s3.listObjectsV2(request)
+    }
+}

--- a/src/main/kotlin/com/geekbeast/rhizome/aws/S3ListingIterator.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/aws/S3ListingIterator.kt
@@ -1,0 +1,74 @@
+package com.geekbeast.rhizome.aws
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.ListObjectsV2Request
+import com.amazonaws.services.s3.model.ListObjectsV2Result
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * This is the base class for s3 listing iterator.
+ *
+ * This class will make a call to s3 using the provided client at creation in order to initialize
+ * the listing iterator and paging mechanism.
+ */
+abstract class S3ListingIterator<T> @JvmOverloads constructor(
+        private val s3: AmazonS3,
+        private val bucket: String,
+        protected val folderPrefix: String,
+        private val maxKeys: Int = 1000,
+        protected val delimiter: String = "/",
+        private val mapper: (String) -> T
+) : Iterator<T> {
+    private val lock = ReentrantLock()
+    private var continuationToken: String? = null
+    protected var result = getNextListing()
+    protected var index = 0
+
+    init {
+        continuationToken = result.nextContinuationToken
+    }
+
+    override fun next(): T {
+        val nextElem = try {
+            lock.lock()
+            require(hasNext()) { "No element available." }
+            if (index == result.commonPrefixes.size) {
+                result = getNextListing()
+                continuationToken = result.nextContinuationToken
+                index = 0
+            }
+            getElement(index++)
+        } finally {
+            lock.unlock()
+        }
+
+        return mapper(trimElement(nextElem))
+    }
+
+    abstract fun trimElement(nextElem: String): String
+    abstract fun getElement( index: Int ) : String
+    abstract fun getBufferLength() : Int
+
+    override fun hasNext(): Boolean {
+        return try {
+            lock.lock()
+            (index < getBufferLength()) || (continuationToken != null)
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    private fun getNextListing(): ListObjectsV2Result {
+        val request = ListObjectsV2Request()
+                .withBucketName(bucket)
+                .withPrefix(folderPrefix)
+                .withDelimiter(delimiter)
+                .withMaxKeys(maxKeys)
+
+        if (continuationToken != null) {
+            request.continuationToken = continuationToken
+        }
+
+        return s3.listObjectsV2(request)
+    }
+}

--- a/src/main/kotlin/com/geekbeast/rhizome/aws/S3ObjectListingIterable.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/aws/S3ObjectListingIterable.kt
@@ -1,0 +1,87 @@
+package com.geekbeast.rhizome.aws
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.ListObjectsV2Request
+import com.amazonaws.services.s3.model.ListObjectsV2Result
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ *
+ * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
+ */
+class S3ObjectListingIterable<T>(
+        private val s3: AmazonS3,
+        private val bucket: String,
+        private val folderPrefix: String,
+        private val maxKeys: Int = 1000,
+        private val delimiter: String = "/",
+        private val mapper: (String) -> T
+) : Iterable<T> {
+    override fun iterator(): Iterator<T> {
+        return S3ObjectIterator(
+                s3, bucket, folderPrefix, maxKeys, delimiter, mapper
+        )
+    }
+
+}
+
+/**
+ * This class will list
+ */
+class S3ObjectIterator<T> @JvmOverloads constructor(
+        private val s3: AmazonS3,
+        private val bucket: String,
+        private val folderPrefix: String,
+        private val maxKeys: Int = 1000,
+        private val delimiter: String = "/",
+        private val mapper: (String) -> T
+) : Iterator<T> {
+    private val lock = ReentrantLock()
+    private var continuationToken: String? = null
+    private var result = getNextListing()
+    private var index = 0
+
+    init {
+        continuationToken = result.nextContinuationToken
+    }
+
+    override fun next(): T {
+        val nextElem = try {
+            lock.lock()
+            require(hasNext()) { "No element available." }
+            if (index == result.commonPrefixes.size) {
+                result = getNextListing()
+                continuationToken = result.nextContinuationToken
+                index = 0
+            }
+            result.objectSummaries[index++].key
+        } finally {
+            lock.unlock()
+        }
+
+        return mapper(nextElem.removePrefix(folderPrefix))
+    }
+
+    override fun hasNext(): Boolean {
+        return try {
+            lock.lock()
+            (index < result.objectSummaries.size) || (continuationToken != null)
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    private fun getNextListing(): ListObjectsV2Result {
+        val request = ListObjectsV2Request()
+                .withBucketName(bucket)
+                .withPrefix(folderPrefix)
+                .withDelimiter(delimiter)
+                .withMaxKeys(maxKeys)
+
+        if (continuationToken != null) {
+            request.continuationToken = continuationToken
+        }
+
+        return s3.listObjectsV2(request)
+    }
+}

--- a/src/main/kotlin/com/geekbeast/rhizome/aws/S3ObjectListingIterable.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/aws/S3ObjectListingIterable.kt
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ListObjectsV2Request
 import com.amazonaws.services.s3.model.ListObjectsV2Result
 import java.util.concurrent.locks.ReentrantLock
+import kotlin.math.max
 
 /**
  *
@@ -22,66 +23,21 @@ class S3ObjectListingIterable<T>(
                 s3, bucket, folderPrefix, maxKeys, delimiter, mapper
         )
     }
-
 }
 
 /**
  * This class will list
  */
 class S3ObjectIterator<T> @JvmOverloads constructor(
-        private val s3: AmazonS3,
-        private val bucket: String,
-        private val folderPrefix: String,
-        private val maxKeys: Int = 1000,
-        private val delimiter: String = "/",
-        private val mapper: (String) -> T
-) : Iterator<T> {
-    private val lock = ReentrantLock()
-    private var continuationToken: String? = null
-    private var result = getNextListing()
-    private var index = 0
+        s3: AmazonS3,
+        bucket: String,
+        folderPrefix: String,
+        maxKeys: Int = 1000,
+        delimiter: String = "/",
+        mapper: (String) -> T
+) : S3ListingIterator<T>(s3, bucket, folderPrefix, maxKeys, delimiter, mapper) {
 
-    init {
-        continuationToken = result.nextContinuationToken
-    }
-
-    override fun next(): T {
-        val nextElem = try {
-            lock.lock()
-            require(hasNext()) { "No element available." }
-            if (index == result.commonPrefixes.size) {
-                result = getNextListing()
-                continuationToken = result.nextContinuationToken
-                index = 0
-            }
-            result.objectSummaries[index++].key
-        } finally {
-            lock.unlock()
-        }
-
-        return mapper(nextElem.removePrefix(folderPrefix))
-    }
-
-    override fun hasNext(): Boolean {
-        return try {
-            lock.lock()
-            (index < result.objectSummaries.size) || (continuationToken != null)
-        } finally {
-            lock.unlock()
-        }
-    }
-
-    private fun getNextListing(): ListObjectsV2Result {
-        val request = ListObjectsV2Request()
-                .withBucketName(bucket)
-                .withPrefix(folderPrefix)
-                .withDelimiter(delimiter)
-                .withMaxKeys(maxKeys)
-
-        if (continuationToken != null) {
-            request.continuationToken = continuationToken
-        }
-
-        return s3.listObjectsV2(request)
-    }
+    override fun trimElement(nextElem: String): String = nextElem.removePrefix(folderPrefix)
+    override fun getElement(index: Int): String = result.objectSummaries[index].key
+    override fun getBufferLength(): Int = result.objectSummaries.size
 }


### PR DESCRIPTION
This implements s3 iterables which is needed to make it easier to list all entity key ids for an entity set in S3. This is useful for being able to clear an entity set without having to query to the postgres metastore for the rest of the stack.