### PR TITLE
Feature/http2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -253,6 +253,8 @@ dependencies {
     compile "org.eclipse.jetty.websocket:websocket-server:${jetty_version}"
     compile "org.eclipse.jetty.websocket:javax-websocket-server-impl:${jetty_version}"
     compile "org.eclipse.jetty:jetty-continuation:${jetty_version}"
+    compile "org.eclipse.jetty:jetty-alpn-java-server:${jetty_version}"
+    compile "org.eclipse.jetty.http2:http2-server:${jetty_version}"
 
     compile "io.netty:netty-transport-native-epoll:${netty_epoll_version}:${netty_os_arch}"
 
@@ -316,6 +318,16 @@ dependencies {
     compile "com.auth0:auth0:${project.auth0_version}"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+}
+
+tasks.withType(Test) {
+    jvmArgs += [ "--add-modules", "java.se",
+                 "--add-exports","java.base/jdk.internal.ref=ALL-UNNAMED",
+                 "--add-opens","java.base/java.lang=ALL-UNNAMED",
+                 "--add-opens","java.base/java.nio=ALL-UNNAMED",
+                 "--add-opens","java.base/sun.nio.ch=ALL-UNNAMED",
+                 "--add-opens","java.management/sun.management=ALL-UNNAMED",
+                 "--add-opens","jdk.management/com.sun.management.internal=ALL-UNNAMED"]
 }
 
 eclipse {

--- a/src/main/java/com/geekbeast/rhizome/core/JettyAnnotationConfigurationWorkaround.java
+++ b/src/main/java/com/geekbeast/rhizome/core/JettyAnnotationConfigurationWorkaround.java
@@ -1,6 +1,7 @@
-package com.kryptnostic.rhizome.core;
+package com.geekbeast.rhizome.core;
 
 import com.google.common.collect.Lists;
+import com.kryptnostic.rhizome.core.Rhizome;
 import java.util.List;
 
 import javax.servlet.ServletContainerInitializer;

--- a/src/main/java/com/kryptnostic/rhizome/configuration/jetty/ConnectorConfiguration.java
+++ b/src/main/java/com/kryptnostic/rhizome/configuration/jetty/ConnectorConfiguration.java
@@ -11,30 +11,33 @@ import java.util.Random;
  * @author Matthew Tamayo-Rios
  */
 @JsonIgnoreProperties(
-    ignoreUnknown = false )
+        ignoreUnknown = false )
 public class ConnectorConfiguration {
-    protected static final String    HTTP_PORT_PROPERTY         = "http-port";
-    protected static final String    HTTPS_PORT_PROPERTY        = "https-port";
-    protected static final String    USE_SSL_PROPERTY           = "use-ssl";
-    protected static final String    REQUIRE_SSL_PROPERTY       = "require-ssl";
-    protected static final String    NEED_CLIENT_AUTH_PROPERTY  = "require-client-auth";
-    protected static final String    WANT_CLIENT_AUTH_PROPERTY  = "want-client-auth";
-    protected static final String    CERTIFICATE_ALIAS_PROPERTY = "certificate-alias";
+    protected static final String HTTP_PORT_PROPERTY         = "http-port";
+    protected static final String HTTPS_PORT_PROPERTY        = "https-port";
+    protected static final String USE_SSL_PROPERTY           = "use-ssl";
+    protected static final String REQUIRE_SSL_PROPERTY       = "require-ssl";
+    protected static final String NEED_CLIENT_AUTH_PROPERTY  = "require-client-auth";
+    protected static final String WANT_CLIENT_AUTH_PROPERTY  = "want-client-auth";
+    protected static final String CERTIFICATE_ALIAS_PROPERTY = "certificate-alias";
+    protected static final String HTTP2_ENABLED_PROPERTY     = "http2-enabled";
 
-    protected static final int       HTTP_PORT_DEFAULT          = 8081;
-    protected static final int       SSL_PORT_DEFAULT           = 8443;
-    protected static final boolean   NEED_CLIENT_AUTH_DEFAULT   = false;
-    protected static final boolean   WANT_CLIENT_AUTH_DEFAULT   = false;
-    protected static final boolean   USE_SSL_DEFAULT            = false;
-    protected static final boolean   REQUIRE_SSL_DEFAULT        = false;
+    protected static final int     HTTP_PORT_DEFAULT        = 8081;
+    protected static final int     SSL_PORT_DEFAULT         = 8443;
+    protected static final boolean NEED_CLIENT_AUTH_DEFAULT = false;
+    protected static final boolean WANT_CLIENT_AUTH_DEFAULT = false;
+    protected static final boolean USE_SSL_DEFAULT          = false;
+    protected static final boolean REQUIRE_SSL_DEFAULT      = false;
+    protected static final boolean HTTP2_ENABLED_DEFAULT    = false;
 
-    protected int                    httpPort;
-    protected int                    httpsPort;
     protected final boolean          needClientAuth;
     protected final boolean          wantClientAuth;
     protected final boolean          useSSL;
     protected final boolean          requireSSL;
     protected final Optional<String> certificateAlias;
+    protected final boolean          http2Enabled;
+    protected       int              httpPort;
+    protected       int              httpsPort;
 
     /*
      * Pass in 0 for port numbers to automatically generate random ports for unit testing / integration testing.
@@ -43,16 +46,17 @@ public class ConnectorConfiguration {
     @JsonCreator
     public ConnectorConfiguration(
             @JsonProperty(
-                value = HTTP_PORT_PROPERTY,
-                required = true ) Optional<Integer> httpPort,
+                    value = HTTP_PORT_PROPERTY,
+                    required = true ) Optional<Integer> httpPort,
             @JsonProperty(
-                value = HTTPS_PORT_PROPERTY,
-                required = true ) Optional<Integer> httpsPort,
+                    value = HTTPS_PORT_PROPERTY,
+                    required = true ) Optional<Integer> httpsPort,
+            @JsonProperty( HTTP2_ENABLED_PROPERTY ) Optional<Boolean> http2Enabled,
             @JsonProperty( USE_SSL_PROPERTY ) Optional<Boolean> useSSL,
             @JsonProperty( REQUIRE_SSL_PROPERTY ) Optional<Boolean> requireSSL,
             @JsonProperty( NEED_CLIENT_AUTH_PROPERTY ) Optional<Boolean> needClientAuth,
             @JsonProperty( WANT_CLIENT_AUTH_PROPERTY ) Optional<Boolean> wantClientAuth,
-            @JsonProperty( CERTIFICATE_ALIAS_PROPERTY ) Optional<String> certificateAlias) {
+            @JsonProperty( CERTIFICATE_ALIAS_PROPERTY ) Optional<String> certificateAlias ) {
         final Random r = new Random( System.currentTimeMillis() );
 
         if ( httpPort.isPresent() && httpPort.get() == 0 ) {
@@ -67,6 +71,7 @@ public class ConnectorConfiguration {
             this.httpsPort = httpsPort.orElse( SSL_PORT_DEFAULT );
         }
 
+        this.http2Enabled = http2Enabled.orElse( HTTP2_ENABLED_DEFAULT );
         this.useSSL = useSSL.orElse( USE_SSL_DEFAULT );
         this.requireSSL = requireSSL.orElse( REQUIRE_SSL_DEFAULT );
         this.needClientAuth = needClientAuth.orElse( NEED_CLIENT_AUTH_DEFAULT );
@@ -74,14 +79,27 @@ public class ConnectorConfiguration {
         this.certificateAlias = certificateAlias;
     }
 
+    @JsonProperty( HTTP2_ENABLED_PROPERTY )
+    public boolean isHttp2Enabled() {
+        return http2Enabled;
+    }
+
     @JsonProperty( HTTP_PORT_PROPERTY )
     public int getHttpPort() {
         return httpPort;
     }
 
+    public void setHttpPort( int httpPort ) {
+        this.httpPort = httpPort;
+    }
+
     @JsonProperty( HTTPS_PORT_PROPERTY )
     public int getHttpsPort() {
         return httpsPort;
+    }
+
+    public void setHttpsPort( int httpsPort ) {
+        this.httpsPort = httpsPort;
     }
 
     @JsonProperty( NEED_CLIENT_AUTH_PROPERTY )
@@ -107,13 +125,5 @@ public class ConnectorConfiguration {
     @JsonProperty( CERTIFICATE_ALIAS_PROPERTY )
     public Optional<String> getCertificateAlias() {
         return certificateAlias;
-    }
-
-    public void setHttpPort( int httpPort ) {
-        this.httpPort = httpPort;
-    }
-
-    public void setHttpsPort( int httpsPort ) {
-        this.httpsPort = httpsPort;
     }
 }

--- a/src/main/java/com/kryptnostic/rhizome/configuration/jetty/ConnectorConfiguration.java
+++ b/src/main/java/com/kryptnostic/rhizome/configuration/jetty/ConnectorConfiguration.java
@@ -28,7 +28,7 @@ public class ConnectorConfiguration {
     protected static final boolean WANT_CLIENT_AUTH_DEFAULT = false;
     protected static final boolean USE_SSL_DEFAULT          = false;
     protected static final boolean REQUIRE_SSL_DEFAULT      = false;
-    protected static final boolean HTTP2_ENABLED_DEFAULT    = false;
+    protected static final boolean HTTP2_ENABLED_DEFAULT    = true;
 
     protected final boolean          needClientAuth;
     protected final boolean          wantClientAuth;

--- a/src/main/java/com/kryptnostic/rhizome/configuration/jetty/JettyConfiguration.java
+++ b/src/main/java/com/kryptnostic/rhizome/configuration/jetty/JettyConfiguration.java
@@ -13,41 +13,44 @@ import java.util.Optional;
 /**
  * @author Matthew Tamayo-Rios
  */
-@ReloadableConfiguration(uri="jetty.yaml")
+@ReloadableConfiguration( uri = "jetty.yaml" )
 public class JettyConfiguration implements Configuration {
-    private static final long                        serialVersionUID                        = 129440984814569272L;
+    protected static final String KEYMANAGER_PASSWORD_PROPERTY            = "keymanager-password";
+    protected static final String MAX_THREADS_PROPERTY                    = "max-threads";
+    protected static final String CONTEXT_CONFIGURATION_PROPERTY          = "context";
+    protected static final String KEYSTORE_CONFIGURATION_PROPERTY         = "keystore";
+    protected static final String TRUSTSTORE_CONFIGURATION_PROPERTY       = "truststore";
+    protected static final String WEB_ENDPOINT_CONFIGURATION_PROPERTY     = "web-endpoint";
+    protected static final String SERVICE_ENDPOINT_CONFIGURATION_PROPERTY = "service-endpoint";
+    protected static final String SECURITY_ENABLE_PROPERTY                = "security-enabled";
+    protected static final String GZIP_CONFIGURATION_PROPERTY             = "gzip";
+    protected static final String DEFAULT_SERVLET_ENABLED_PROPERTY        = "default-servlet-enabled";
 
-    protected static ConfigurationKey                key                                     = new SimpleConfigurationKey(
+    protected static final int     MAX_THREADS_DEFAULT             = 500;
+    protected static final boolean DEFAULT_SERVLET_ENABLED_DEFAULT = false;
+
+    private static final long serialVersionUID = 129440984814569272L;
+
+    protected static ConfigurationKey key = new SimpleConfigurationKey(
             "jetty.yaml" );
-
-    protected static final String                    KEYMANAGER_PASSWORD_PROPERTY            = "keymanager-password";
-    protected static final String                    MAX_THREADS_PROPERTY                    = "max-threads";
-    protected static final String                    CONTEXT_CONFIGURATION_PROPERTY          = "context";
-    protected static final String                    KEYSTORE_CONFIGURATION_PROPERTY         = "keystore";
-    protected static final String                    TRUSTSTORE_CONFIGURATION_PROPERTY       = "truststore";
-    protected static final String                    WEB_ENDPOINT_CONFIGURATION_PROPERTY     = "web-endpoint";
-    protected static final String                    SERVICE_ENDPOINT_CONFIGURATION_PROPERTY = "service-endpoint";
-    protected static final String                    SECURITY_ENABLE_PROPERTY                = "security-enabled";
-    protected static final String                    GZIP_CONFIGURATION_PROPERTY             = "gzip";
-    protected static final String                    DEFAULT_SERVLET_ENABLED_PROPERTY        = "default-servlet-enabled";
-    protected static final int                       MAX_THREADS_DEFAULT                     = 500;
-    protected static final boolean                   DEFAULT_SERVLET_ENABLED_DEFAULT         = false;
 
     protected final Optional<String>                 keymanagerPassword;
     protected final int                              maxThreads;
-    protected final boolean                               securityEnabled;
-    protected final boolean                               defaultServletEnabled;
-    protected final Optional<ConnectorConfiguration>      webConnectorConfiguration;
-    protected final Optional<ConnectorConfiguration>      serviceConnectorConfiguration;
-    protected final Optional<ContextConfiguration>        contextConfiguration;
-    protected final Optional<KeystoreConfiguration>       keystoreConfiguration;
-    protected final Optional<KeystoreConfiguration>       truststoreConfiguration;
-    protected final Optional<GzipConfiguration> gzipConfiguration;
+    protected final boolean                          securityEnabled;
+    protected final boolean                          defaultServletEnabled;
+    protected final Optional<ConnectorConfiguration> webConnectorConfiguration;
+    protected final Optional<ConnectorConfiguration> serviceConnectorConfiguration;
+    protected final Optional<ContextConfiguration>   contextConfiguration;
+    protected final Optional<KeystoreConfiguration>  keystoreConfiguration;
+    protected final Optional<KeystoreConfiguration>  truststoreConfiguration;
+    protected final Optional<GzipConfiguration>      gzipConfiguration;
 
     @JsonCreator
     public JettyConfiguration(
-            @JsonProperty( WEB_ENDPOINT_CONFIGURATION_PROPERTY ) Optional<ConnectorConfiguration> webConnectorConfiguration,
-            @JsonProperty( SERVICE_ENDPOINT_CONFIGURATION_PROPERTY ) Optional<ConnectorConfiguration> serviceConnectorConfiguration,
+            @JsonProperty( WEB_ENDPOINT_CONFIGURATION_PROPERTY )
+                    Optional<ConnectorConfiguration> webConnectorConfiguration,
+            @JsonProperty( SERVICE_ENDPOINT_CONFIGURATION_PROPERTY )
+                    Optional<ConnectorConfiguration> serviceConnectorConfiguration,
             @JsonProperty( MAX_THREADS_PROPERTY ) Optional<Integer> maxThreads,
             @JsonProperty( DEFAULT_SERVLET_ENABLED_PROPERTY ) Optional<Boolean> defaultServletEnabled,
             @JsonProperty( KEYMANAGER_PASSWORD_PROPERTY ) Optional<String> keymanagerPassword,
@@ -69,10 +72,6 @@ public class JettyConfiguration implements Configuration {
         this.gzipConfiguration = gzipConfiguration;
         this.securityEnabled = securityEnabled.orElse( false );
         this.defaultServletEnabled = defaultServletEnabled.orElse( DEFAULT_SERVLET_ENABLED_DEFAULT );
-    }
-
-    public static ConfigurationKey key() {
-        return key;
     }
 
     @Override
@@ -129,6 +128,10 @@ public class JettyConfiguration implements Configuration {
     @JsonProperty( MAX_THREADS_PROPERTY )
     public int getMaxThreads() {
         return maxThreads;
+    }
+
+    public static ConfigurationKey key() {
+        return key;
     }
 
 }

--- a/src/main/java/com/kryptnostic/rhizome/core/JettyAnnotationConfigurationHack.java
+++ b/src/main/java/com/kryptnostic/rhizome/core/JettyAnnotationConfigurationHack.java
@@ -36,7 +36,7 @@ public class JettyAnnotationConfigurationHack extends AnnotationConfiguration {
     @Override
     public void createServletContainerInitializerAnnotationHandlers(
             WebAppContext context,
-            List<ServletContainerInitializer> scis ) throws Exception {
+            List<ServletContainerInitializer> scis ) {
         if ( scis == null || scis.isEmpty() ) return; // nothing to do
 
         final List<ContainerInitializer> initializers = new ArrayList<>();

--- a/src/main/java/com/kryptnostic/rhizome/core/JettyAnnotationConfigurationWorkaround.java
+++ b/src/main/java/com/kryptnostic/rhizome/core/JettyAnnotationConfigurationWorkaround.java
@@ -1,19 +1,11 @@
 package com.kryptnostic.rhizome.core;
 
 import com.google.common.collect.Lists;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.ServletContainerInitializer;
-import javax.servlet.annotation.HandlesTypes;
-
 
 import org.eclipse.jetty.annotations.AnnotationConfiguration;
-import org.eclipse.jetty.annotations.ClassInheritanceHandler;
-import org.eclipse.jetty.annotations.ContainerInitializerAnnotationHandler;
-import org.eclipse.jetty.annotations.ServletContainerInitializersStarter;
 import org.eclipse.jetty.plus.annotation.ContainerInitializer;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
@@ -25,8 +17,8 @@ import org.eclipse.jetty.webapp.WebAppContext;
  * 
  * @author Matthew Tamayo-Rios
  */
-public class JettyAnnotationConfigurationHack extends AnnotationConfiguration {
-    private static final Logger       LOG                    = Log.getLogger( JettyAnnotationConfigurationHack.class );
+public class JettyAnnotationConfigurationWorkaround extends AnnotationConfiguration {
+    private static final Logger       LOG                    = Log.getLogger( JettyAnnotationConfigurationWorkaround.class );
     private static final List<String> additionalInitializers = Lists.newArrayList();
 
     static {

--- a/src/main/java/com/kryptnostic/rhizome/core/JettyLoam.java
+++ b/src/main/java/com/kryptnostic/rhizome/core/JettyLoam.java
@@ -86,7 +86,7 @@ public class JettyLoam implements Loam {
          */
 
         classlist.addBefore(classlist.get(0),//"org.eclipse.jetty.webapp.JettyWebXmlConfiguration",
-                "com.kryptnostic.rhizome.core.JettyAnnotationConfigurationWorkaround");
+                "com.geekbeast.rhizome.core.JettyAnnotationConfigurationWorkaround");
 
         //This would enable standard AnnotationConfiguration processing by Jetty
         //classlist.addBefore(classlist.get(0),//"org.eclipse.jetty.webapp.JettyWebXmlConfiguration",

--- a/src/main/java/com/kryptnostic/rhizome/core/JettyLoam.java
+++ b/src/main/java/com/kryptnostic/rhizome/core/JettyLoam.java
@@ -1,5 +1,6 @@
 package com.kryptnostic.rhizome.core;
 
+import com.geekbeast.rhizome.core.JettyAnnotationConfigurationWorkaround;
 import com.kryptnostic.rhizome.configuration.amazon.AmazonLaunchConfiguration;
 import com.kryptnostic.rhizome.configuration.jetty.ConnectorConfiguration;
 import com.kryptnostic.rhizome.configuration.jetty.ContextConfiguration;
@@ -25,7 +26,6 @@ import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.Configuration.ClassList;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.slf4j.Logger;

--- a/src/main/java/com/kryptnostic/rhizome/core/Rhizome.java
+++ b/src/main/java/com/kryptnostic/rhizome/core/Rhizome.java
@@ -1,14 +1,18 @@
 package com.kryptnostic.rhizome.core;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.servlets.AdminServlet;
 import com.codahale.metrics.servlets.HealthCheckServlet;
 import com.codahale.metrics.servlets.MetricsServlet;
+import com.geekbeast.rhizome.services.ServiceState;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.google.common.eventbus.EventBus;
 import com.google.common.io.Resources;
 import com.hazelcast.web.SessionListener;
 import com.hazelcast.web.WebFilter;
@@ -51,7 +55,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * TODO: break out WebApplicationInitializer's onStartup to a different class because of Jetty issue
  */
 public class Rhizome implements WebApplicationInitializer {
-    protected static final Class<?>[]                            DEFAULT_SERVICE_PODS          = new Class<?>[] {
+    protected static final Class<?>[]                            REQUIRED_RHIZOME_PODS         = new Class<?>[] {
             ConfigurationPod.class,
             MetricsPod.class,
             AsyncPod.class };
@@ -60,8 +64,10 @@ public class Rhizome implements WebApplicationInitializer {
             .getLogger( Rhizome.class );
     private static final   String                                HAZELCAST_SESSION_FILTER_NAME = "hazelcastSessionFilter";
     protected static       AnnotationConfigWebApplicationContext rhizomeContext                = null;
-    protected final        AnnotationConfigWebApplicationContext context;
-    private                JettyLoam                             jetty;
+
+    protected final AnnotationConfigWebApplicationContext context;
+    private         JettyLoam                             jetty;
+    private         EventBus                              eventBus;
 
     public Rhizome() {
         this( new Class<?>[] {} );
@@ -100,6 +106,9 @@ public class Rhizome implements WebApplicationInitializer {
         RhizomeConfiguration configuration = rhizomeContext.getBean( RhizomeConfiguration.class );
         JettyConfiguration jettyConfiguration = rhizomeContext.getBean( JettyConfiguration.class );
 
+        /*
+         * Setup hazelcast to provide an IMap to back session storage.
+         */
         if ( configuration.isSessionClusteringEnabled() ) {
             FilterRegistration.Dynamic addFilter = servletContext.addFilter(
                     HAZELCAST_SESSION_FILTER_NAME,
@@ -127,13 +136,17 @@ public class Rhizome implements WebApplicationInitializer {
                 rhizomeContext.getBean( "getMetricRegistry", MetricRegistry.class ) );
 
         /*
-         *
+         * Setup metrics admin servlet
          */
 
         ServletRegistration.Dynamic adminServlet = servletContext.addServlet( "admin", AdminServlet.class );
         adminServlet.setLoadOnStartup( 1 );
         adminServlet.addMapping( "/admin/*" );
         adminServlet.setInitParameter( "show-jvm-metrics", "true" );
+
+        /*
+         * Setup prometheus servlet
+         */
 
         ServletRegistration.Dynamic prometheusServlet = servletContext.addServlet(
                 "prometheus",
@@ -199,6 +212,61 @@ public class Rhizome implements WebApplicationInitializer {
         }
     }
 
+    public void sprout( String... activeProfiles ) {
+        boolean awsProfile = shoot( context, activeProfiles );
+
+        /*
+         * This will trigger creation of Jetty, so we: 1) Lock on singleton context 2) switch in the correct singleton
+         * context 3) set back to null and release lock once Jetty has finished starting.
+         */
+        try {
+            startupLock.lock();
+            checkState(
+                    rhizomeContext == null,
+                    "Rhizome context should be null before startup of startup." );
+            rhizomeContext = context;
+            context.refresh();
+            eventBus = rhizomeContext.getBean( EventBus.class );
+            startJetty( awsProfile );
+        } catch ( Exception e ) {
+            logger.error( "Something went wrong during startup", e );
+            System.exit( 1 );
+        } finally {
+            rhizomeContext = null;
+            showBannerIfStartedOrExit( jetty, context );
+            startupLock.unlock();
+            eventBus.post( ServiceState.RUNNING );
+        }
+    }
+
+    protected void startJetty( boolean awsProfile ) throws Exception {
+        JettyConfiguration jettyConfig = Preconditions.checkNotNull( rhizomeContext.getBean( JettyConfiguration.class ),
+                "Jetty configuration cannot be null" );
+        if ( awsProfile ) {
+            this.jetty = new AwsJettyLoam( jettyConfig,
+                    Preconditions.checkNotNull( rhizomeContext.getBean( AmazonLaunchConfiguration.class ),
+                            "AwsConfig cannot be null" ) );
+        } else {
+            // For now we assume just AWS as an alternate to a local profile.
+            this.jetty = new JettyLoam( jettyConfig );
+        }
+
+        eventBus.post( ServiceState.JETTY_STARTING );
+
+        jetty.start();
+
+        eventBus.post( ServiceState.JETTY_STARTED );
+    }
+
+    public void wilt() throws Exception {
+        jetty.stop();
+        context.close();
+    }
+
+    public Class<?>[] getDefaultServicePods() {
+        return REQUIRED_RHIZOME_PODS;
+    }
+
     public static boolean shoot( AbstractApplicationContext context, String... activeProfiles ) {
         boolean awsProfile = false;
         boolean localProfile = false;
@@ -223,64 +291,17 @@ public class Rhizome implements WebApplicationInitializer {
         return awsProfile;
     }
 
-    public void sprout( String... activeProfiles ) {
-        boolean awsProfile = shoot( context, activeProfiles );
-
-        /*
-         * This will trigger creation of Jetty, so we: 1) Lock on singleton context 2) switch in the correct singleton
-         * context 3) set back to null and release lock once Jetty has finished starting.
-         */
-        try {
-            startupLock.lock();
-            Preconditions.checkState(
-                    rhizomeContext == null,
-                    "Rhizome context should be null before startup of startup." );
-            rhizomeContext = context;
-            context.refresh();
-            startJetty( awsProfile );
-        } catch ( Exception e ) {
-            logger.error( "Something went wrong during startup", e );
-        } finally {
-            rhizomeContext = null;
-
-            if ( !this.jetty.getServer().isStarted() ) {
-                logger.warn( "Jetty has not started." );
-            }
-
-            showBannerIfStarted( context );
-            startupLock.unlock();
-        }
+    static void showBannerIfStartedOrExit( JettyLoam jetty, AbstractApplicationContext context ) {
+        checkState( jetty.getServer().isStarted(), "Jetty server is not started." );
+        showBannerIfStartedOrExit( context );
     }
 
-    static void showBannerIfStarted(AbstractApplicationContext context ) {
-        if ( context.isActive() && context.isRunning() && startupRequirementsSatisfied( context ) ) {
-            showBanner();
-        }
-    }
+    static void showBannerIfStartedOrExit( AbstractApplicationContext context ) {
+        checkState( context.isRunning(), "Application context is not running." );
+        checkState( context.isActive(), "Application context is not active." );
+        checkState( startupRequirementsSatisfied( context ), "Startup requiremetns have not been met." );
 
-    protected void startJetty( boolean awsProfile ) throws Exception {
-        JettyConfiguration jettyConfig = Preconditions.checkNotNull( rhizomeContext.getBean( JettyConfiguration.class ),
-                        "Jetty configuration cannot be null" );
-        if ( awsProfile ) {
-            this.jetty = new AwsJettyLoam( jettyConfig,
-                    Preconditions.checkNotNull( rhizomeContext.getBean( AmazonLaunchConfiguration.class ),
-                            "AwsConfig cannot be null" ) );
-        } else {
-            // For now we assume just AWS as an alternate to a local profile.
-            this.jetty = new JettyLoam( jettyConfig );
-        }
-        jetty.start();
-    }
-
-    public void wilt() throws Exception {
-        jetty.stop();
-        context.close();
-    }
-
-    // This method is not static so it can be sub-classed and overridden.
-
-    public Class<?>[] getDefaultServicePods() {
-        return DEFAULT_SERVICE_PODS;
+        showBanner();
     }
 
     public static void showBanner() {

--- a/src/main/java/com/kryptnostic/rhizome/core/Rhizome.java
+++ b/src/main/java/com/kryptnostic/rhizome/core/Rhizome.java
@@ -299,7 +299,7 @@ public class Rhizome implements WebApplicationInitializer {
     static void showBannerIfStartedOrExit( AbstractApplicationContext context ) {
         checkState( context.isRunning(), "Application context is not running." );
         checkState( context.isActive(), "Application context is not active." );
-        checkState( startupRequirementsSatisfied( context ), "Startup requiremetns have not been met." );
+        checkState( startupRequirementsSatisfied( context ), "Startup requirements have not been met." );
 
         showBanner();
     }

--- a/src/main/java/com/kryptnostic/rhizome/core/RhizomeApplicationServer.java
+++ b/src/main/java/com/kryptnostic/rhizome/core/RhizomeApplicationServer.java
@@ -15,17 +15,17 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.kryptnostic.rhizome.core.Rhizome.shoot;
-import static com.kryptnostic.rhizome.core.Rhizome.showBannerIfStarted;
+import static com.kryptnostic.rhizome.core.Rhizome.showBannerIfStartedOrExit;
 
 public class RhizomeApplicationServer {
-    private final        AnnotationConfigApplicationContext context        = new AnnotationConfigApplicationContext();
-    private final        List<Class<?>>                     additionalPods = new ArrayList<>();
-    public static final  Class<?>[]                         DEFAULT_PODS   = new Class<?>[] {
+    public static final Class<?>[]                         DEFAULT_PODS   = new Class<?>[] {
             AsyncPod.class,
             ConfigurationPod.class,
             ConfigurationLoaderPod.class,
             HazelcastPod.class,
             RegistryBasedHazelcastInstanceConfigurationPod.class };
+    private final       AnnotationConfigApplicationContext context        = new AnnotationConfigApplicationContext();
+    private final       List<Class<?>>                     additionalPods = new ArrayList<>();
 
     public RhizomeApplicationServer( Class<?>... pods ) {
         this( DEFAULT_PODS, pods );
@@ -47,7 +47,8 @@ public class RhizomeApplicationServer {
         }
         context.refresh();
 
-        showBannerIfStarted( context );
+        showBannerIfStartedOrExit( context );
+
     }
 
     public void plowUnder() {

--- a/src/main/java/com/kryptnostic/rhizome/pods/AsyncPod.java
+++ b/src/main/java/com/kryptnostic/rhizome/pods/AsyncPod.java
@@ -60,7 +60,7 @@ public class AsyncPod implements AsyncConfigurer, SchedulingConfigurer {
     }
 
     @Bean
-    public AsyncEventBus localConfigurationUpdates() {
+    public AsyncEventBus eventBus() {
         return new AsyncEventBus( getAsyncExecutor() );
     }
 

--- a/src/main/java/com/openlattice/auth0/Auth0SecurityPod.java
+++ b/src/main/java/com/openlattice/auth0/Auth0SecurityPod.java
@@ -22,7 +22,7 @@ package com.openlattice.auth0;
 
 import com.auth0.client.auth.AuthAPI;
 import com.auth0.spring.security.api.JwtWebSecurityConfigurer;
-import com.kryptnostic.rhizome.core.JettyAnnotationConfigurationWorkaround;
+import com.geekbeast.rhizome.core.JettyAnnotationConfigurationWorkaround;
 import com.kryptnostic.rhizome.core.RhizomeSecurity;
 import com.openlattice.authentication.Auth0AuthenticationConfiguration;
 import com.openlattice.authentication.Auth0Configuration;

--- a/src/main/java/com/openlattice/auth0/Auth0SecurityPod.java
+++ b/src/main/java/com/openlattice/auth0/Auth0SecurityPod.java
@@ -22,7 +22,7 @@ package com.openlattice.auth0;
 
 import com.auth0.client.auth.AuthAPI;
 import com.auth0.spring.security.api.JwtWebSecurityConfigurer;
-import com.kryptnostic.rhizome.core.JettyAnnotationConfigurationHack;
+import com.kryptnostic.rhizome.core.JettyAnnotationConfigurationWorkaround;
 import com.kryptnostic.rhizome.core.RhizomeSecurity;
 import com.openlattice.authentication.Auth0AuthenticationConfiguration;
 import com.openlattice.authentication.Auth0Configuration;
@@ -51,7 +51,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 public class Auth0SecurityPod extends WebSecurityConfigurerAdapter {
 
     static {
-        JettyAnnotationConfigurationHack.registerInitializer( RhizomeSecurity.class.getCanonicalName() );
+        JettyAnnotationConfigurationWorkaround.registerInitializer( RhizomeSecurity.class.getCanonicalName() );
     }
 
     @Inject

--- a/src/main/kotlin/com/geekbeast/rhizome/services/ServiceState.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/services/ServiceState.kt
@@ -1,0 +1,11 @@
+package com.geekbeast.rhizome.services
+
+/**
+ *
+ * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
+ */
+enum class ServiceState {
+    JETTY_STARTING,
+    JETTY_STARTED,
+    RUNNING
+}

--- a/src/test/java/com/geekbeast/rhizome/tests/bootstrap/RhizomeRunner.java
+++ b/src/test/java/com/geekbeast/rhizome/tests/bootstrap/RhizomeRunner.java
@@ -1,0 +1,29 @@
+package com.geekbeast.rhizome.tests.bootstrap;
+
+import com.geekbeast.rhizome.tests.authentication.Auth0SecurityTestPod;
+import com.geekbeast.rhizome.tests.pods.DispatcherServletsPod;
+import com.kryptnostic.rhizome.core.Rhizome;
+import com.kryptnostic.rhizome.pods.ConfigurationLoaderPod;
+import com.kryptnostic.rhizome.pods.hazelcast.RegistryBasedHazelcastInstanceConfigurationPod;
+import com.openlattice.auth0.Auth0Pod;
+import com.openlattice.authentication.AuthenticationTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
+ */
+public class RhizomeRunner {
+    private static final Logger logger = LoggerFactory.getLogger( RhizomeRunner.class );
+    public static void main(String[] args ) {
+        logger.info("Token: {}", AuthenticationTest.authenticate().getCredentials());
+        final var rhizome = new Rhizome(
+                ConfigurationLoaderPod.class,
+                Auth0Pod.class,
+                Auth0SecurityTestPod.class,
+                DispatcherServletsPod.class,
+                RegistryBasedHazelcastInstanceConfigurationPod.class );
+        rhizome.sprout();
+        logger.info( "Successfully started Rhizome microservice." );
+    }
+}


### PR DESCRIPTION
Gives Rhizome some overdue love and care:

- Adds ALPN + HTTP2 and HTTP2c support.
- Cleans up the AnnotationConfiguration workaround to be more maintainable.
- Startup stages are now published on the local EventBus
- Adds jvm args for hazelcast dependencies.
- Also should except with clearer exceptions for some cases of startup failure