### PR TITLE
Added commonly used missing functions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ plugins {
     id 'idea'
     id 'jacoco'
     id 'com.github.spotbugs' version '4.0.0'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.61'
-    id 'org.jetbrains.kotlin.plugin.spring' version '1.3.61'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
+    id 'org.jetbrains.kotlin.plugin.spring' version '1.3.72'
     id 'org.jetbrains.dokka' version '0.9.18'
 }
 

--- a/src/test/kotlin/com/geekbeast/rhizome/hazelcast/HazelcastMapInMemoryMock.kt
+++ b/src/test/kotlin/com/geekbeast/rhizome/hazelcast/HazelcastMapInMemoryMock.kt
@@ -2,10 +2,24 @@ package com.geekbeast.rhizome.hazelcast
 
 import com.google.common.collect.Maps
 import com.hazelcast.core.IMap
+import com.hazelcast.internal.serialization.InternalSerializationService
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder
+import com.hazelcast.internal.serialization.impl.SerializationServiceV1
+import com.hazelcast.nio.serialization.Data
+import com.hazelcast.nio.serialization.StreamSerializer
 import com.hazelcast.query.Predicate
+import com.hazelcast.query.impl.CachedQueryEntry
+import com.hazelcast.query.impl.QueryableEntry
+import com.hazelcast.query.impl.getters.Extractors
+import com.kryptnostic.rhizome.pods.hazelcast.SelfRegisteringStreamSerializer
 import org.mockito.Matchers.any
 import org.mockito.Mockito
+import java.util.concurrent.locks.ReentrantLock
 
+
+private val _ss = DefaultSerializationServiceBuilder().build()
+private val registered = mutableSetOf<Class<*>>()
+private val registrationLock = ReentrantLock()
 
 /**
  * Mocks a hazelcast using a concurrent map. It implements put,putIfAbsent, get,set, and [] operator.
@@ -16,26 +30,48 @@ import org.mockito.Mockito
  * @param valueClass A reference to the class of the value used for the map
  * @return A mocked IMap backed by a concurrent map.
  */
-fun <K,V> mockHazelcastMap(keyClass:Class<K>, valueClass: Class<V>) : IMap<K,V> {
-    val mock =  Mockito.mock<IMap<*,*>>( IMap::class.java) as IMap<K,V>
-    val backingMap = Maps.newConcurrentMap<K,V>()
+fun <K, V> mockHazelcastMap(
+        keyClass: Class<K>,
+        valueClass: Class<V>,
+        streamSerializers: List<SelfRegisteringStreamSerializer<*>> = listOf(),
+        ss: InternalSerializationService = _ss,
+        extractors: Extractors = Extractors.newBuilder(ss).setMapAttributeConfigs(listOf()).setClassLoader(keyClass.classLoader).build()
+): IMap<K, V> {
+    val mock = Mockito.mock<IMap<*, *>>(IMap::class.java) as IMap<K, V>
+    val backingMap = Maps.newConcurrentMap<K, V>() as MutableMap<K,V>
+//    val ssMap = streamSerializers.associateBy { it.clazz }
+//    val keyStreamSerializer = getSerializers(ssMap, keyClass)
+//    val valueStreamSerializer = getSerializers(ssMap, valueClass)
+
+    if (ss is SerializationServiceV1) {
+        try {
+            registrationLock.lock()
+            streamSerializers.forEach {
+                if (!registered.contains(it.clazz)) {
+                    ss.register(it.clazz, it)
+                    registered.add(it.clazz)
+                }
+            }
+        } finally {
+            registrationLock.unlock()
+        }
+    }
 
     Mockito.`when`(mock.put(any(keyClass), any(valueClass))).thenAnswer {
         val k = it.arguments[0] as K
-        val v  = it.arguments[1] as V
-        backingMap.put( k, v )
+        val v = it.arguments[1] as V
+        backingMap.put(k, v)
     }
 
     Mockito.`when`(mock.putIfAbsent(any(keyClass), any(valueClass))).thenAnswer {
         val k = it.arguments[0] as K
-        val v  = it.arguments[1] as V
-        backingMap.putIfAbsent( k, v )
+        val v = it.arguments[1] as V
+        backingMap.putIfAbsent(k, v)
     }
-
 
     Mockito.`when`(mock.set(any(keyClass), any(valueClass))).thenAnswer {
         val k = it.arguments[0] as K
-        val v  = it.arguments[1] as V
+        val v = it.arguments[1] as V
         backingMap[k] = v
         Unit
     }
@@ -56,20 +92,50 @@ fun <K,V> mockHazelcastMap(keyClass:Class<K>, valueClass: Class<V>) : IMap<K,V> 
         backingMap.remove(k)
     }
 
-    Mockito.`when`(mock.entrySet(any(Predicate::class.java))).thenAnswer {
-        val p = it.arguments[0] as Predicate<K,V>
-        backingMap.asSequence().filter( p::apply ).toSet()
+    Mockito.`when`(mock.entrySet(any(Predicate::class.java))).thenAnswer { invocation ->
+        val p = invocation.arguments[0] as Predicate<K, V>
+        backingMap.asSequence()
+                .map { CachedQueryEntry<K, V>(ss, ss.toData(it.component1()), it.component2(), extractors) }
+                .filter(p::apply)
+                .toSet()
     }
 
     Mockito.`when`(mock.keySet(any(Predicate::class.java))).thenAnswer { it ->
-        val p = it.arguments[0] as Predicate<K,V>
-        backingMap.asSequence().filter( p::apply ).map{ entry -> entry.component1() }.toSet()
+        val p = it.arguments[0] as Predicate<K, V>
+        backingMap.asSequence()
+                .map{ CachedQueryEntry<K, V>(ss,ss.toData(it.component1()),it.component2(),extractors) }
+                .filter(p::apply)
+                .map { entry -> entry.component1() }
+                .toSet()
     }
 
     Mockito.`when`(mock.values(any(Predicate::class.java))).thenAnswer { it ->
-        val p = it.arguments[0] as Predicate<K,V>
-        backingMap.asSequence().filter( p::apply ).map{ entry -> entry.component1() }.toList()
+        val p = it.arguments[0] as Predicate<K, V>
+        backingMap.asSequence()
+                .map{ CachedQueryEntry<K, V>(ss,ss.toData(it.component1()),it.component2(),extractors) }
+                .filter(p::apply)
+                .map { entry -> entry.component1() }
+                .toList()
     }
-    
+
+    Mockito.`when`(mock.entries).thenAnswer{ backingMap.entries }
+    Mockito.`when`(mock.keys).thenAnswer{ backingMap.keys }
+    Mockito.`when`(mock.values).thenAnswer{ backingMap.values }
+    Mockito.`when`(mock.size).thenAnswer{ backingMap.size }
+    Mockito.`when`(mock.count()).thenAnswer { backingMap.count() }
+    Mockito.`when`(mock.clear()).thenAnswer{ backingMap.clear() }
+
     return mock
 }
+
+/**
+ * Gets the correct stream serializer by first trying a lookup and then a linear search if that fails.
+ * @param streamSerializers The map of stream serializers.
+ * @param clazz The class for which a serializer is desired.
+ */
+private fun getSerializers(
+        streamSerializers: Map<Class<*>, SelfRegisteringStreamSerializer<*>>,
+        clazz: Class<*>
+) = streamSerializers[clazz]
+        ?: streamSerializers.getValue(streamSerializers.keys.first { it.isAssignableFrom(clazz) })
+

--- a/src/test/kotlin/com/geekbeast/rhizome/hazelcast/HazelcastQueueInMemoryMock.kt
+++ b/src/test/kotlin/com/geekbeast/rhizome/hazelcast/HazelcastQueueInMemoryMock.kt
@@ -16,30 +16,30 @@ import java.util.concurrent.TimeUnit
  * @param valueClass A reference to the class of the value used for the map
  * @return A mocked IMap backed by a concurrent map.
  */
-fun <V> mockHazelcastQueue(valueClass: Class<V>) : IQueue<V> {
-    val mock =  Mockito.mock<IQueue<*>>( IQueue::class.java) as IQueue<V>
+fun <V> mockHazelcastQueue(valueClass: Class<V>): IQueue<V> {
+    val mock = Mockito.mock<IQueue<*>>(IQueue::class.java) as IQueue<V>
     val backingQueue = Queues.newArrayBlockingQueue<V>(10000)
 
     Mockito.`when`(mock.put(any(valueClass))).thenAnswer {
-        val v  = it.arguments[0] as V
-        backingQueue.put(v )
+        val v = it.arguments[0] as V
+        backingQueue.put(v)
     }
 
     Mockito.`when`(mock.add(any(valueClass))).thenAnswer {
-        val v  = it.arguments[0] as V
-        backingQueue.add( v )
+        val v = it.arguments[0] as V
+        backingQueue.add(v)
     }
 
     Mockito.`when`(mock.offer(any(valueClass))).thenAnswer {
-        val v  = it.arguments[0] as V
-        backingQueue.offer( v )
+        val v = it.arguments[0] as V
+        backingQueue.offer(v)
     }
 
-    Mockito.`when`(mock.offer(any(valueClass),any(Long::class.java),any(TimeUnit::class.java))).thenAnswer {
-        val v  = it.arguments[0] as V
+    Mockito.`when`(mock.offer(any(valueClass), any(Long::class.java), any(TimeUnit::class.java))).thenAnswer {
+        val v = it.arguments[0] as V
         val timeout = it.arguments[1] as Long
         val timeUnit = it.arguments[2] as TimeUnit
-        backingQueue.offer( v, timeout, timeUnit )
+        backingQueue.offer(v, timeout, timeUnit)
     }
 
     Mockito.`when`(mock.take()).thenAnswer {
@@ -50,11 +50,14 @@ fun <V> mockHazelcastQueue(valueClass: Class<V>) : IQueue<V> {
         backingQueue.poll()
     }
 
-    Mockito.`when`(mock.poll(any(Long::class.java),any(TimeUnit::class.java))).thenAnswer {
+    Mockito.`when`(mock.poll(any(Long::class.java), any(TimeUnit::class.java))).thenAnswer {
         val timeout = it.arguments[0] as Long
         val timeUnit = it.arguments[1] as TimeUnit
-        backingQueue.poll( timeout, timeUnit )
+        backingQueue.poll(timeout, timeUnit)
     }
-    
+
+    Mockito.`when`(mock.clear()).thenAnswer { backingQueue.clear() }
+    Mockito.`when`(mock.size).thenAnswer { backingQueue.size }
+
     return mock
 }


### PR DESCRIPTION
Implement some commonly used missing functions. Also fixed an issue where predicates couldn't be correctly applied, because they expected to evaluated on QueryableEntry. Current solution isn't great, but implementing QueryableEntry would have introduced potential drift between the attribute reading code we copied over and what Hazelcast implements.