### PR TITLE
Add initialize hook and don't process batches when paused.

### DIFF
--- a/src/main/kotlin/com/geekbeast/rhizome/jobs/AbstractDistributedJob.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/jobs/AbstractDistributedJob.kt
@@ -145,7 +145,7 @@ abstract class AbstractDistributedJob<R, S : JobState>(
     /**
      * This function can be override to specify setup behavior that occurs after task starts running.
      */
-    protected fun initialize(){}
+    protected open fun initialize(){}
 
     abstract fun processNextBatch()
 

--- a/src/main/kotlin/com/geekbeast/rhizome/jobs/AbstractDistributedJob.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/jobs/AbstractDistributedJob.kt
@@ -142,9 +142,14 @@ abstract class AbstractDistributedJob<R, S : JobState>(
         logger.info(msg())
     }
 
+    /**
+     * This function can be override to specify setup behavior that occurs after task starts running.
+     */
+    protected fun initialize(){}
+
     abstract fun processNextBatch()
 
-    private fun initializeTask() {
+    private fun initializeOrResumeJob() {
         /**
          * There are two resumption cases we need to handle at initialization
          *
@@ -168,6 +173,7 @@ abstract class AbstractDistributedJob<R, S : JobState>(
         } else if (status == JobStatus.PENDING) {
             //If status is pending then job is new and we just need to mark as running.
             status = JobStatus.RUNNING
+            initialize()
         }
     }
 
@@ -183,7 +189,7 @@ abstract class AbstractDistributedJob<R, S : JobState>(
 
     final override fun call(): R? {
         //Wait until task id has been assigned and can be retrieved.
-        initializeTaskId()
+        pollForTaskId()
 
         /**
          * If the job status is paused we poll for a job status update every five seconds, otherwise we process
@@ -194,9 +200,10 @@ abstract class AbstractDistributedJob<R, S : JobState>(
             do {
                 if (status == JobStatus.PAUSED) {
                     Thread.sleep(PAUSE_POLLING_MILLIS)
+                } else {
+                    initializeOrResumeJob()
+                    processBatches()
                 }
-                initializeTask()
-                processBatches()
             } while (resumable && status == JobStatus.PAUSED)
         } catch (ex: InterruptedException) {
             logger.warn("Distributed job $taskId was interrupted.", ex)
@@ -218,7 +225,7 @@ abstract class AbstractDistributedJob<R, S : JobState>(
         }
     }
 
-    private fun initializeTaskId() {
+    private fun pollForTaskId() {
         if (taskId != null) return
 
         require(id != null) { "Cannot initialize task when id has not been initialized." }

--- a/src/main/kotlin/com/geekbeast/rhizome/jobs/AbstractDistributedJob.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/jobs/AbstractDistributedJob.kt
@@ -236,7 +236,13 @@ abstract class AbstractDistributedJob<R, S : JobState>(
         }
     }
 
+    /**
+     * Overridable function that allows updating progress before job state is published.
+     */
+    protected open fun updateProgress() {}
+
     protected fun publishJobState() {
+        updateProgress()
         //Do not replace with indexing operator
         jobs.set(id, this)
     }

--- a/src/main/kotlin/com/geekbeast/rhizome/jobs/AbstractDistributedJob.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/jobs/AbstractDistributedJob.kt
@@ -143,7 +143,7 @@ abstract class AbstractDistributedJob<R, S : JobState>(
     }
 
     /**
-     * This function can be override to specify setup behavior that occurs after task starts running.
+     * This function can be override to specify setup behavior that occurs before task starts running.
      */
     protected open fun initialize(){}
 

--- a/src/main/kotlin/com/geekbeast/rhizome/jobs/EmptyJob.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/jobs/EmptyJob.kt
@@ -1,17 +1,35 @@
+/*
+ * Copyright (C) 2020. OpenLattice, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can contact the owner of the copyright at support@openlattice.com
+ *
+ *
+ */
+
 package com.geekbeast.rhizome.jobs
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import org.apache.commons.lang3.RandomUtils
-import java.lang.IllegalStateException
 import java.util.*
 
 /**
  *
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
-data class EmptyJobState(val name: String) : JobState
-
-class EmptyJob(
+internal class EmptyJob(
         state: EmptyJobState,
         fail: Boolean = false,
         private val rounds: Int = 10

--- a/src/main/kotlin/com/geekbeast/rhizome/jobs/EmptyJobState.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/jobs/EmptyJobState.kt
@@ -21,27 +21,9 @@
 
 package com.geekbeast.rhizome.jobs
 
-import com.openlattice.serializer.AbstractJacksonSerializationTest
-import org.apache.commons.lang3.RandomStringUtils
-import org.apache.commons.lang3.RandomUtils
-import java.util.*
-
 /**
  *
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
-class JobSerializationTests : AbstractJacksonSerializationTest<EmptyJob>() {
-    override fun getSampleData(): EmptyJob {
-        val job = EmptyJob(EmptyJobState(RandomStringUtils.random(5)))
-        job.initTaskId(RandomUtils.nextLong())
-        job.initId(UUID.randomUUID())
-        return job
-    }
-
-    override fun logResult(result: SerializationResult<EmptyJob>?) {
-        logger.info("Json: ${result?.jsonString}")
-    }
-
-    override fun getClazz(): Class<EmptyJob> = EmptyJob::class.java
-}
+internal data class EmptyJobState(val name: String) : JobState
 

--- a/src/main/kotlin/com/geekbeast/rhizome/jobs/PostgresJobsMapStore.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/jobs/PostgresJobsMapStore.kt
@@ -41,7 +41,7 @@ import java.util.*
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
 @Component
-class PostgresJobsMapStore(
+class PostgresJobsMapStore @JvmOverloads constructor(
         hds: HikariDataSource,
         private val mapper: ObjectMapper = ObjectMappers.getJsonMapper()
 ) : AbstractBasePostgresMapstore<UUID, DistributableJob<*>>(JOBS_MAP, JOBS, hds, BATCH_SIZE) {

--- a/src/main/kotlin/com/geekbeast/rhizome/jobs/PostgresJobsMapStore.kt
+++ b/src/main/kotlin/com/geekbeast/rhizome/jobs/PostgresJobsMapStore.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020. OpenLattice, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can contact the owner of the copyright at support@openlattice.com
+ *
+ *
+ */
+
+package com.geekbeast.rhizome.jobs
+
+import com.dataloom.mappers.ObjectMappers
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.openlattice.postgres.PostgresColumnDefinition
+import com.openlattice.postgres.PostgresDatatype
+import com.openlattice.postgres.PostgresTableDefinition
+import com.openlattice.postgres.mapstores.AbstractBasePostgresMapstore
+import com.zaxxer.hikari.HikariDataSource
+import org.apache.commons.lang3.RandomUtils
+import org.springframework.stereotype.Component
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.util.*
+
+/**
+ * Provides a postgres based backing map store for jobs.
+ *
+ * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
+ */
+@Component
+class PostgresJobsMapStore(
+        hds: HikariDataSource,
+        private val mapper: ObjectMapper = ObjectMappers.getJsonMapper()
+) : AbstractBasePostgresMapstore<UUID, DistributableJob<*>>(JOBS_MAP, JOBS, hds, BATCH_SIZE) {
+    override fun generateTestKey(): UUID = UUID.randomUUID()
+    override fun generateTestValue(): DistributableJob<*> {
+        val job = EmptyJob(EmptyJobState("testValue"))
+        job.initId(UUID.randomUUID())
+        job.initTaskId(RandomUtils.nextLong(0, Long.MAX_VALUE))
+        return job
+    }
+
+    override fun mapToKey(rs: ResultSet): UUID = rs.getObject(ID_FIELD, UUID::class.java)
+
+    override fun mapToValue(rs: ResultSet): DistributableJob<*> = mapper.readValue(rs.getString(JOB_FIELD))
+
+    override fun bind(ps: PreparedStatement, key: UUID, value: DistributableJob<*>?) {
+        val json = mapper.writeValueAsString(value)
+        ps.setObject(1, key)
+        ps.setString(2, json)
+        ps.setString(3, json)
+
+    }
+
+    override fun bind(ps: PreparedStatement, key: UUID, offset: Int): Int {
+        ps.setObject(1, key)
+        return -1
+    }
+}
+
+const val ID_FIELD = "id"
+const val JOB_FIELD = "job"
+private val ID_COLUMN = PostgresColumnDefinition(ID_FIELD, PostgresDatatype.UUID).primaryKey().notNull()
+private val JOB_COLUMN = PostgresColumnDefinition(JOB_FIELD, PostgresDatatype.JSONB).notNull()
+private val JOBS = PostgresTableDefinition("jobs").addColumns(ID_COLUMN, JOB_COLUMN)

--- a/src/test/kotlin/com/geekbeast/rhizome/hazelcast/serializers/EmptyJobStreamSerializer.kt
+++ b/src/test/kotlin/com/geekbeast/rhizome/hazelcast/serializers/EmptyJobStreamSerializer.kt
@@ -2,6 +2,7 @@ package com.geekbeast.rhizome.hazelcast.serializers
 
 import com.dataloom.mappers.ObjectMappers
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.geekbeast.rhizome.jobs.DistributableJob
 import com.geekbeast.rhizome.jobs.EmptyJob
 import com.hazelcast.nio.ObjectDataInput
 import com.hazelcast.nio.ObjectDataOutput
@@ -13,15 +14,15 @@ import org.springframework.stereotype.Component
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
 @Component
-class EmptyJobStreamSerializer : SelfRegisteringStreamSerializer<EmptyJob> {
+class EmptyJobStreamSerializer : SelfRegisteringStreamSerializer<DistributableJob<*>> {
     private val mapper = ObjectMappers.getSmileMapper()
 
     override fun getTypeId(): Int = TestStreamSerializersTypeIds.EMPTY_JOB.ordinal
 
-    override fun write(out: ObjectDataOutput, `object`: EmptyJob) {
+    override fun write(out: ObjectDataOutput, `object`: DistributableJob<*>) {
         out.writeByteArray(mapper.writeValueAsBytes(`object`))
     }
 
-    override fun read(`in`: ObjectDataInput): EmptyJob = mapper.readValue(`in`.readByteArray())
-    override fun getClazz(): Class<out EmptyJob> = EmptyJob::class.java
+    override fun read(`in`: ObjectDataInput): DistributableJob<*> = mapper.readValue(`in`.readByteArray())
+    override fun getClazz(): Class<out DistributableJob<*>> = DistributableJob::class.java
 }

--- a/src/test/kotlin/com/geekbeast/rhizome/jobs/HazelcastJobServiceTest.kt
+++ b/src/test/kotlin/com/geekbeast/rhizome/jobs/HazelcastJobServiceTest.kt
@@ -47,10 +47,18 @@ class HazelcastJobServiceTest : RhizomeTests() {
 
     @Test
     fun testJobService() {
-        val ids = setOf(jobService.submitJob(EmptyJob(EmptyJobState(RandomStringUtils.random(5)))),
-        jobService.submitJob(EmptyJob(EmptyJobState(RandomStringUtils.random(5)))),
-        jobService.submitJob(EmptyJob(EmptyJobState(RandomStringUtils.random(5)))),
-        jobService.submitJob(EmptyJob(EmptyJobState(RandomStringUtils.random(5)))))
+        val ids = setOf(jobService.submitJob(EmptyJob(
+                EmptyJobState(RandomStringUtils.random(5))
+        )),
+                        jobService.submitJob(EmptyJob(
+                                EmptyJobState(RandomStringUtils.random(5))
+                        )),
+                        jobService.submitJob(EmptyJob(
+                                EmptyJobState(RandomStringUtils.random(5))
+                        )),
+                        jobService.submitJob(EmptyJob(
+                                EmptyJobState(RandomStringUtils.random(5))
+                        )))
         Assert.assertTrue( ids.size == 4 )
         val jobs = jobService.getJobs()
         Assert.assertEquals(4, jobs.size)
@@ -63,7 +71,8 @@ class HazelcastJobServiceTest : RhizomeTests() {
 
     @Test
     fun testFailedJob() {
-        val id = jobService.submitJob(EmptyJob(EmptyJobState(RandomStringUtils.random(5)), fail = true))
+        val id = jobService.submitJob(EmptyJob(
+                EmptyJobState(RandomStringUtils.random(5)), fail = true))
 
         val (job, result) = jobService.getResultAndDisposeOfTask<Long>(id)
         Assert.assertNull( result )

--- a/src/test/kotlin/com/geekbeast/rhizome/jobs/JobSerializationTests.kt
+++ b/src/test/kotlin/com/geekbeast/rhizome/jobs/JobSerializationTests.kt
@@ -30,7 +30,7 @@ import java.util.*
  *
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
-class JobSerializationTests : AbstractJacksonSerializationTest<EmptyJob>() {
+internal class JobSerializationTests : AbstractJacksonSerializationTest<EmptyJob>() {
     override fun getSampleData(): EmptyJob {
         val job = EmptyJob(EmptyJobState(RandomStringUtils.random(5)))
         job.initTaskId(RandomUtils.nextLong())


### PR DESCRIPTION
Adds an initialize hook for jobs to setup job state before processing and fixes an issue where batches ran even when task was paused.