### PR TITLE
De-dupe Auth0 configuration 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext.developerConnectionUrl = 'scm:git:https://github.com/geekbeast/rhizome.git'
 
 apply from: "https://raw.githubusercontent.com/openlattice/gradles/master/openlattice.gradle"
 apply plugin: 'kotlin'
-apply from: "https://raw.githubusercontent.com/openlattice/gradles/master/repos.gradle" \
+apply from: "https://raw.githubusercontent.com/openlattice/gradles/master/repos.gradle"
 
 mainClassName = "com.kryptnostic.rhizome.core.RhizomeAws"
 
@@ -268,7 +268,7 @@ dependencies {
      */
     compile "org.jodd:jodd-mail:${jodd_mail_version}"
 
-    /**
+    /*
      * Cassandra
      */
     compile "org.xerial.snappy:snappy-java:${snappy_version}"

--- a/src/main/kotlin/com/openlattice/auth0/Auth0Delegate.kt
+++ b/src/main/kotlin/com/openlattice/auth0/Auth0Delegate.kt
@@ -1,0 +1,54 @@
+package com.openlattice.auth0
+
+import com.auth0.client.auth.AuthAPI
+import com.auth0.exception.Auth0Exception
+import com.google.common.annotations.VisibleForTesting
+import com.openlattice.authentication.Auth0Configuration
+
+class Auth0Delegate
+@JvmOverloads
+private constructor(
+        val auth0domain: String,
+        val auth0clientId: String,
+        val auth0Connection: String = DEFAULT_AUTH0_CONNECTION,
+        val auth0Scopes: String = DEFAULT_AUTH0_SCOPES ,
+        val auth0Api: AuthAPI = AuthAPI(auth0domain, auth0clientId, "")
+) {
+    private constructor(
+            config: Auth0Configuration
+    ): this( config.domain, config.clientId )
+
+    companion object {
+        private const val DEFAULT_AUTH0_CONNECTION = "Username-Password-Authentication"
+        private const val DEFAULT_AUTH0_SCOPES = "openid email nickname roles user_id organizations"
+
+        @JvmStatic
+        @VisibleForTesting
+        fun fromConfig(config: Auth0Configuration ): Auth0Delegate {
+            return Auth0Delegate( config )
+        }
+
+        @JvmStatic
+        @VisibleForTesting
+        fun fromConstants(domain: String, clientId: String, auth0Connection: String, auth0Scopes: String): Auth0Delegate {
+            return Auth0Delegate( domain, clientId, auth0Connection, auth0Scopes)
+        }
+    }
+
+    @VisibleForTesting
+    @Throws(Auth0Exception::class)
+    fun getIdToken(username: String, password: String ): String {
+        return getIdToken(auth0Connection, username, password)
+    }
+
+    @VisibleForTesting
+    @Throws(Auth0Exception::class)
+    fun getIdToken(realm: String, username: String, password: String): String {
+        return auth0Api
+                .login(username, password.toCharArray(), realm)
+                .setScope(auth0Scopes)
+                .setAudience("https://api.openlattice.com")
+                .execute()
+                .idToken
+    }
+}


### PR DESCRIPTION
This PR:
- create a new structure to decouple various projects from shuttle and allows outside consumers to more easily configure their Auth0 usage