### PR TITLE
Set core pool size based on available processors.

### DIFF
--- a/src/main/java/com/kryptnostic/rhizome/pods/AsyncPod.java
+++ b/src/main/java/com/kryptnostic/rhizome/pods/AsyncPod.java
@@ -22,7 +22,8 @@ import java.util.Arrays;
 @EnableScheduling
 @EnableAsync
 public class AsyncPod implements AsyncConfigurer, SchedulingConfigurer {
-    private static Logger logger = LoggerFactory.getLogger( AsyncPod.class );
+    private static final Logger logger         = LoggerFactory.getLogger( AsyncPod.class );
+    private static final int    CORE_POOL_SIZE = 8;
 
     // TODO: Make thread names prefixes configurable.
     @Override
@@ -44,11 +45,9 @@ public class AsyncPod implements AsyncConfigurer, SchedulingConfigurer {
     @Bean(
             destroyMethod = "shutdown" )
     public ThreadPoolTaskExecutor getAsyncExecutor() {
-        int minPoolSize = 4;
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize( minPoolSize );
-        executor.setMaxPoolSize( Math.max( minPoolSize, Runtime.getRuntime().availableProcessors()));
-        logger.info("Setting MaxPoolSize to " + executor.getMaxPoolSize());
+        executor.setCorePoolSize( Math.max( CORE_POOL_SIZE, Runtime.getRuntime().availableProcessors() ) );
+        logger.info( "Setting MaxPoolSize to " + executor.getMaxPoolSize() );
         executor.setThreadNamePrefix( "rhizome-offshoot-" );
         executor.initialize();
         return executor;


### PR DESCRIPTION
When using an unbounded queue new threads are never created since offer to queue always succeeds. This ensures that the thread pool will will seek to have at least be max( 8, # of cores) available for asynchronous work